### PR TITLE
Implement rollback engine

### DIFF
--- a/src/main/java/net/caseif/flint/steel/SteelMain.java
+++ b/src/main/java/net/caseif/flint/steel/SteelMain.java
@@ -30,6 +30,9 @@ package net.caseif.flint.steel;
 
 import net.caseif.flint.steel.listener.player.PlayerConnectionListener;
 import net.caseif.flint.steel.listener.player.PlayerWorldListener;
+import net.caseif.flint.steel.listener.rollback.RollbackBlockListener;
+import net.caseif.flint.steel.listener.rollback.RollbackEntityListener;
+import net.caseif.flint.steel.listener.rollback.RollbackInventoryListener;
 import net.caseif.flint.steel.util.io.DataFiles;
 
 import net.gravitydevelopment.updater.Updater;
@@ -53,16 +56,24 @@ public class SteelMain extends JavaPlugin {
 	public void onEnable() {
 		plugin = this;
 		SteelCore.initialize();
+
         Bukkit.getPluginManager().registerEvents(new PlayerConnectionListener(), getPlugin());
 		Bukkit.getPluginManager().registerEvents(new PlayerWorldListener(), getPlugin());
+
+        Bukkit.getPluginManager().registerEvents(new RollbackBlockListener(), getPlugin());
+        Bukkit.getPluginManager().registerEvents(new RollbackEntityListener(), getPlugin());
+        Bukkit.getPluginManager().registerEvents(new RollbackInventoryListener(), getPlugin());
+
         saveDefaultConfig();
 		DataFiles.createCoreDataFiles();
+
 		try {
 			Class.forName("org.sqlite.JDBC"); // load the SQL driver
 		} catch (ClassNotFoundException ex) {
 			getLogger().severe("Failed to load SQL driver");
 			ex.printStackTrace();
 		}
+
 		initMetrics();
 		//initUpdater(); //TODO
 	}

--- a/src/main/java/net/caseif/flint/steel/SteelMain.java
+++ b/src/main/java/net/caseif/flint/steel/SteelMain.java
@@ -57,6 +57,12 @@ public class SteelMain extends JavaPlugin {
 		Bukkit.getPluginManager().registerEvents(new PlayerWorldListener(), getPlugin());
         saveDefaultConfig();
 		DataFiles.createCoreDataFiles();
+		try {
+			Class.forName("org.sqlite.JDBC"); // load the SQL driver
+		} catch (ClassNotFoundException ex) {
+			getLogger().severe("Failed to load SQL driver");
+			ex.printStackTrace();
+		}
 		initMetrics();
 		//initUpdater(); //TODO
 	}

--- a/src/main/java/net/caseif/flint/steel/arena/SteelArena.java
+++ b/src/main/java/net/caseif/flint/steel/arena/SteelArena.java
@@ -45,18 +45,12 @@ import net.caseif.flint.util.physical.Location3D;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
-import org.bukkit.Location;
-import org.bukkit.block.BlockState;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.YamlConfiguration;
 
 import java.io.File;
 import java.io.IOException;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.Map;
 
 /**
@@ -72,8 +66,6 @@ public class SteelArena extends CommonArena {
     public static final String PERSISTENCE_BOUNDS_UPPER_KEY = "bound.upper";
     public static final String PERSISTENCE_BOUNDS_LOWER_KEY = "bound.lower";
     public static final String PERSISTENCE_METADATA_KEY = "metadata";
-
-    private static final String ROLLBACK_STORE_BLOCK_TABLE = "blocks";
 
     public SteelArena(CommonMinigame parent, String id, String name, Location3D initialSpawn, Boundary boundary) {
         super(parent, id, name, initialSpawn, boundary);
@@ -174,22 +166,6 @@ public class SteelArena extends CommonArena {
             } else if (section.isString(key)) {
                 parent.set(key, section.getString(key));
             }
-        }
-    }
-
-    public void logBlockChange(Location location, BlockState originalState)
-            throws IOException, SQLException {
-        File rollbackStore = new File(DataFiles.ARENA_STORE.getFile(getMinigame()), getId() + ".db");
-        if (!rollbackStore.exists()) {
-            //noinspection ResultOfMethodCallIgnored
-            rollbackStore.createNewFile();
-        }
-        try (Connection conn = DriverManager.getConnection("jdbc:sqlite:" + rollbackStore.getPath())) {
-            Statement st = conn.createStatement();
-            st.execute("SELECT * FROM `" + ROLLBACK_STORE_BLOCK_TABLE + "`"
-                    + " WHERE x=" + location.getX()
-                    + " && y=" + location.getY()
-                    + " && z=" + location.getZ());
         }
     }
 

--- a/src/main/java/net/caseif/flint/steel/arena/SteelArena.java
+++ b/src/main/java/net/caseif/flint/steel/arena/SteelArena.java
@@ -52,6 +52,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
 
 import java.io.File;
 import java.io.IOException;
+import java.sql.SQLException;
 import java.util.Map;
 
 /**
@@ -90,6 +91,15 @@ public class SteelArena extends CommonArena {
         Preconditions.checkArgument(parent.getConfigValue(ConfigNode.DEFAULT_LIFECYCLE_STAGES) != null,
                 "Illegal call to no-args createRound method: default lifecycle stages are not set");
         return createRound(parent.getConfigValue(ConfigNode.DEFAULT_LIFECYCLE_STAGES));
+    }
+
+    @Override
+    public void rollback() throws IllegalStateException {
+        try {
+            getRollbackHelper().popRollbacks();
+        } catch (SQLException ex) {
+            throw new RuntimeException("Failed to rollback arena " + getName(), ex);
+        }
     }
 
     /**

--- a/src/main/java/net/caseif/flint/steel/arena/SteelArena.java
+++ b/src/main/java/net/caseif/flint/steel/arena/SteelArena.java
@@ -141,7 +141,7 @@ public class SteelArena extends CommonArena {
 
     /**
      * Stores the given {@link Metadata} recursively into the given
-     * {@link ConfigurationSection}
+     * {@link ConfigurationSection}.
      *
      * @param section The {@link ConfigurationSection} to store to
      * @param data The {@link Metadata} to store

--- a/src/main/java/net/caseif/flint/steel/arena/SteelArena.java
+++ b/src/main/java/net/caseif/flint/steel/arena/SteelArena.java
@@ -38,6 +38,7 @@ import net.caseif.flint.round.LifecycleStage;
 import net.caseif.flint.round.Round;
 import net.caseif.flint.steel.SteelCore;
 import net.caseif.flint.steel.round.SteelRound;
+import net.caseif.flint.steel.util.helper.RollbackHelper;
 import net.caseif.flint.steel.util.io.DataFiles;
 import net.caseif.flint.util.physical.Boundary;
 import net.caseif.flint.util.physical.Location3D;
@@ -67,8 +68,11 @@ public class SteelArena extends CommonArena {
     public static final String PERSISTENCE_BOUNDS_LOWER_KEY = "bound.lower";
     public static final String PERSISTENCE_METADATA_KEY = "metadata";
 
+    private final RollbackHelper rbHelper;
+
     public SteelArena(CommonMinigame parent, String id, String name, Location3D initialSpawn, Boundary boundary) {
         super(parent, id, name, initialSpawn, boundary);
+        this.rbHelper = new RollbackHelper(this);
     }
 
     @Override
@@ -88,6 +92,24 @@ public class SteelArena extends CommonArena {
         return createRound(parent.getConfigValue(ConfigNode.DEFAULT_LIFECYCLE_STAGES));
     }
 
+    /**
+     * Gets the {@link RollbackHelper} associated with this {@link SteelArena}.
+     *
+     * @return The {@link RollbackHelper} associated with this
+     *     {@link SteelArena}
+     */
+    public RollbackHelper getRollbackHelper() {
+        return rbHelper;
+    }
+
+    /**
+     * Stores this arena into persistent storage.
+     *
+     * @throws InvalidConfigurationException If an exception occurs while
+     *     configuring the persistent store
+     * @throws IOException If an exception occurs while writing to the
+     *     persistent store
+     */
     public void store() throws InvalidConfigurationException, IOException {
         File arenaStore = DataFiles.ARENA_STORE.getFile(getMinigame());
         YamlConfiguration yaml = new YamlConfiguration();
@@ -127,6 +149,12 @@ public class SteelArena extends CommonArena {
         }
     }
 
+    /**
+     * Configures this {@link SteelArena} from the given
+     * {@link ConfigurationSection}.
+     *
+     * @param section The section containing data for this {@link SteelArena}
+     */
     public void configure(ConfigurationSection section) {
         {
             ConfigurationSection spawnSection = section.getConfigurationSection(PERSISTENCE_SPAWNS_KEY);

--- a/src/main/java/net/caseif/flint/steel/arena/SteelArena.java
+++ b/src/main/java/net/caseif/flint/steel/arena/SteelArena.java
@@ -45,12 +45,18 @@ import net.caseif.flint.util.physical.Location3D;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
+import org.bukkit.Location;
+import org.bukkit.block.BlockState;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.YamlConfiguration;
 
 import java.io.File;
 import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.Map;
 
 /**
@@ -66,6 +72,8 @@ public class SteelArena extends CommonArena {
     public static final String PERSISTENCE_BOUNDS_UPPER_KEY = "bound.upper";
     public static final String PERSISTENCE_BOUNDS_LOWER_KEY = "bound.lower";
     public static final String PERSISTENCE_METADATA_KEY = "metadata";
+
+    private static final String ROLLBACK_STORE_BLOCK_TABLE = "blocks";
 
     public SteelArena(CommonMinigame parent, String id, String name, Location3D initialSpawn, Boundary boundary) {
         super(parent, id, name, initialSpawn, boundary);
@@ -166,6 +174,22 @@ public class SteelArena extends CommonArena {
             } else if (section.isString(key)) {
                 parent.set(key, section.getString(key));
             }
+        }
+    }
+
+    public void logBlockChange(Location location, BlockState originalState)
+            throws IOException, SQLException {
+        File rollbackStore = new File(DataFiles.ARENA_STORE.getFile(getMinigame()), getId() + ".db");
+        if (!rollbackStore.exists()) {
+            //noinspection ResultOfMethodCallIgnored
+            rollbackStore.createNewFile();
+        }
+        try (Connection conn = DriverManager.getConnection("jdbc:sqlite:" + rollbackStore.getPath())) {
+            Statement st = conn.createStatement();
+            st.execute("SELECT * FROM `" + ROLLBACK_STORE_BLOCK_TABLE + "`"
+                    + " WHERE x=" + location.getX()
+                    + " && y=" + location.getY()
+                    + " && z=" + location.getZ());
         }
     }
 

--- a/src/main/java/net/caseif/flint/steel/listener/block/RollbackListener.java
+++ b/src/main/java/net/caseif/flint/steel/listener/block/RollbackListener.java
@@ -7,6 +7,7 @@ import net.caseif.flint.steel.arena.SteelArena;
 import net.caseif.flint.steel.util.MiscUtil;
 
 import com.google.common.base.Optional;
+import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -33,10 +34,9 @@ public class RollbackListener implements Listener {
                                     event.getBlock().getLocation(),
                                     event.getBlock().getState()
                             );
-                        } catch (IOException | SQLException ex) {
-                            SteelCore.logSevere("Failed to log block break in arena "
-                                    + challenger.get().getRound().getArena().getName());
-                            ex.printStackTrace();
+                        } catch (InvalidConfigurationException | IOException | SQLException ex) {
+                            throw new RuntimeException("Failed to log block break in arena "
+                                    + challenger.get().getRound().getArena().getName(), ex);
                         }
                     }
                 }

--- a/src/main/java/net/caseif/flint/steel/listener/block/RollbackListener.java
+++ b/src/main/java/net/caseif/flint/steel/listener/block/RollbackListener.java
@@ -1,3 +1,31 @@
+/*
+ * New BSD License (BSD-new)
+ *
+ * Copyright (c) 2015 Maxim Roncacé
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     - Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     - Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     - Neither the name of the copyright holder nor the names of its contributors
+ *       may be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package net.caseif.flint.steel.listener.block;
 
 import net.caseif.flint.Minigame;

--- a/src/main/java/net/caseif/flint/steel/listener/block/RollbackListener.java
+++ b/src/main/java/net/caseif/flint/steel/listener/block/RollbackListener.java
@@ -26,11 +26,10 @@ public class RollbackListener implements Listener {
             Optional<Challenger> challenger = mg.getChallenger(event.getPlayer().getUniqueId());
             if (challenger.isPresent()) {
                 if (challenger.get().getRound().getArena().getWorld().equals(event.getBlock().getWorld().getName())) {
-                    if (!challenger.get().getRound().getArena().getBoundary().isPresent()
-                            || challenger.get().getRound().getArena().getBoundary().get().contains(
+                    if (challenger.get().getRound().getArena().getBoundary().contains(
                             MiscUtil.convertLocation(event.getBlock().getLocation()))) {
                         try {
-                            ((SteelArena)challenger.get().getRound().getArena()).logBlockChange(
+                            ((SteelArena)challenger.get().getRound().getArena()).getRollbackHelper().logBlockChange(
                                     event.getBlock().getLocation(),
                                     event.getBlock().getState()
                             );

--- a/src/main/java/net/caseif/flint/steel/listener/block/RollbackListener.java
+++ b/src/main/java/net/caseif/flint/steel/listener/block/RollbackListener.java
@@ -1,0 +1,48 @@
+package net.caseif.flint.steel.listener.block;
+
+import net.caseif.flint.Minigame;
+import net.caseif.flint.challenger.Challenger;
+import net.caseif.flint.steel.SteelCore;
+import net.caseif.flint.steel.arena.SteelArena;
+import net.caseif.flint.steel.util.MiscUtil;
+
+import com.google.common.base.Optional;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+/**
+ * Listener for events logged by the rollback engine.
+ */
+public class RollbackListener implements Listener {
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onBlockBreak(BlockBreakEvent event) {
+        for (Minigame mg : SteelCore.getMinigames().values()) {
+            Optional<Challenger> challenger = mg.getChallenger(event.getPlayer().getUniqueId());
+            if (challenger.isPresent()) {
+                if (challenger.get().getRound().getArena().getWorld().equals(event.getBlock().getWorld().getName())) {
+                    if (!challenger.get().getRound().getArena().getBoundary().isPresent()
+                            || challenger.get().getRound().getArena().getBoundary().get().contains(
+                            MiscUtil.convertLocation(event.getBlock().getLocation()))) {
+                        try {
+                            ((SteelArena)challenger.get().getRound().getArena()).logBlockChange(
+                                    event.getBlock().getLocation(),
+                                    event.getBlock().getState()
+                            );
+                        } catch (IOException | SQLException ex) {
+                            SteelCore.logSevere("Failed to log block break in arena "
+                                    + challenger.get().getRound().getArena().getName());
+                            ex.printStackTrace();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/java/net/caseif/flint/steel/listener/rollback/RollbackBlockListener.java
+++ b/src/main/java/net/caseif/flint/steel/listener/rollback/RollbackBlockListener.java
@@ -1,0 +1,128 @@
+/*
+ * New BSD License (BSD-new)
+ *
+ * Copyright (c) 2015 Maxim Roncacé
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     - Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     - Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     - Neither the name of the copyright holder nor the names of its contributors
+ *       may be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.caseif.flint.steel.listener.rollback;
+
+import net.caseif.flint.steel.util.helper.RollbackHelper;
+
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockBurnEvent;
+import org.bukkit.event.block.BlockFadeEvent;
+import org.bukkit.event.block.BlockFormEvent;
+import org.bukkit.event.block.BlockFromToEvent;
+import org.bukkit.event.block.BlockGrowEvent;
+import org.bukkit.event.block.BlockMultiPlaceEvent;
+import org.bukkit.event.block.BlockPhysicsEvent;
+import org.bukkit.event.block.BlockPistonExtendEvent;
+import org.bukkit.event.block.BlockPistonRetractEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.block.BlockSpreadEvent;
+
+/**
+ * Listener for physical events logged by the rollback engine.
+ *
+ * @author Max Roncacé
+ */
+public class RollbackBlockListener implements Listener {
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onBlockBreak(BlockBreakEvent event) {
+        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onBlockPlace(BlockPlaceEvent event) {
+        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onBlockBurn(BlockBurnEvent event) {
+        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onBlockFade(BlockFadeEvent event) {
+        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onBlockFromTo(BlockFromToEvent event) {
+        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onBlockSpread(BlockSpreadEvent event) {
+        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onBlockPistonExtend(BlockPistonExtendEvent event) {
+        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState());
+        for (Block b : event.getBlocks()) {
+            RollbackHelper.checkBlockChange(b.getLocation(), b.getState());
+        }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onBlockPistonRetract(BlockPistonRetractEvent event) {
+        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState());
+        for (Block b : event.getBlocks()) {
+            RollbackHelper.checkBlockChange(b.getLocation(), b.getState());
+        }
+        //TODO: some blocks probably won't be rolled back properly
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onBlockForm(BlockFormEvent event) {
+        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onBlockGrow(BlockGrowEvent event) {
+        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onBlockPhysics(BlockPhysicsEvent event) {
+        //TODO: lot of work to do to make this function properly
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onBlockMultiPlace(BlockMultiPlaceEvent event) {
+        for (BlockState state : event.getReplacedBlockStates()) {
+            RollbackHelper.checkBlockChange(state.getLocation(), state.getLocation().getBlock().getState());
+        }
+        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState());
+    }
+
+}

--- a/src/main/java/net/caseif/flint/steel/listener/rollback/RollbackBlockListener.java
+++ b/src/main/java/net/caseif/flint/steel/listener/rollback/RollbackBlockListener.java
@@ -57,73 +57,73 @@ public class RollbackBlockListener implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBlockBreak(BlockBreakEvent event) {
-        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState());
+        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState(), event);
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBlockPlace(BlockPlaceEvent event) {
-        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState());
+        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState(), event);
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBlockBurn(BlockBurnEvent event) {
-        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState());
+        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState(), event);
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBlockFade(BlockFadeEvent event) {
-        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState());
+        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState(), event);
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBlockFromTo(BlockFromToEvent event) {
-        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState());
+        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState(), event);
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBlockSpread(BlockSpreadEvent event) {
-        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState());
+        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState(), event);
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBlockPistonExtend(BlockPistonExtendEvent event) {
-        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState());
+        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState(), event);
         for (Block b : event.getBlocks()) {
-            RollbackHelper.checkBlockChange(b.getLocation(), b.getState());
+            RollbackHelper.checkBlockChange(b.getLocation(), b.getState(), event);
         }
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBlockPistonRetract(BlockPistonRetractEvent event) {
-        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState());
+        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState(), event);
         for (Block b : event.getBlocks()) {
-            RollbackHelper.checkBlockChange(b.getLocation(), b.getState());
+            RollbackHelper.checkBlockChange(b.getLocation(), b.getState(), event);
         }
         //TODO: some blocks probably won't be rolled back properly
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBlockForm(BlockFormEvent event) {
-        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState());
+        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState(), event);
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBlockGrow(BlockGrowEvent event) {
-        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState());
+        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState(), event);
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBlockPhysics(BlockPhysicsEvent event) {
-        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState());
+        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState(), event);
         // the rest of the interaction is logged by the EntityChangeBlockEvent listener
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBlockMultiPlace(BlockMultiPlaceEvent event) {
         for (BlockState state : event.getReplacedBlockStates()) {
-            RollbackHelper.checkBlockChange(state.getLocation(), state.getLocation().getBlock().getState());
+            RollbackHelper.checkBlockChange(state.getLocation(), state.getLocation().getBlock().getState(), event);
         }
-        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState());
+        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState(), event);
     }
 
 }

--- a/src/main/java/net/caseif/flint/steel/listener/rollback/RollbackBlockListener.java
+++ b/src/main/java/net/caseif/flint/steel/listener/rollback/RollbackBlockListener.java
@@ -114,7 +114,8 @@ public class RollbackBlockListener implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBlockPhysics(BlockPhysicsEvent event) {
-        //TODO: lot of work to do to make this function properly
+        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState());
+        // the rest of the interaction is logged by the EntityChangeBlockEvent listener
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)

--- a/src/main/java/net/caseif/flint/steel/listener/rollback/RollbackEntityListener.java
+++ b/src/main/java/net/caseif/flint/steel/listener/rollback/RollbackEntityListener.java
@@ -34,6 +34,7 @@ import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 
 /**
@@ -48,6 +49,12 @@ public class RollbackEntityListener implements Listener {
         for (Block b : event.blockList()) {
             RollbackHelper.checkBlockChange(b.getLocation(), b.getState());
         }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    // covers enderman, falling blocks, and probably other stuff I'm forgetting
+    public void onEntityChangeBlock(EntityChangeBlockEvent event) {
+        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState());
     }
 
 }

--- a/src/main/java/net/caseif/flint/steel/listener/rollback/RollbackEntityListener.java
+++ b/src/main/java/net/caseif/flint/steel/listener/rollback/RollbackEntityListener.java
@@ -1,0 +1,53 @@
+/*
+ * New BSD License (BSD-new)
+ *
+ * Copyright (c) 2015 Maxim Roncacé
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     - Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     - Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     - Neither the name of the copyright holder nor the names of its contributors
+ *       may be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.caseif.flint.steel.listener.rollback;
+
+import net.caseif.flint.steel.util.helper.RollbackHelper;
+
+import org.bukkit.block.Block;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityExplodeEvent;
+
+/**
+ * Listener for entity events logged by the rollback engine.
+ *
+ * @author Max Roncacé
+ */
+public class RollbackEntityListener implements Listener {
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onEntityExplode(EntityExplodeEvent event) {
+        for (Block b : event.blockList()) {
+            RollbackHelper.checkBlockChange(b.getLocation(), b.getState());
+        }
+    }
+
+}

--- a/src/main/java/net/caseif/flint/steel/listener/rollback/RollbackEntityListener.java
+++ b/src/main/java/net/caseif/flint/steel/listener/rollback/RollbackEntityListener.java
@@ -31,11 +31,20 @@ package net.caseif.flint.steel.listener.rollback;
 import net.caseif.flint.steel.util.helper.RollbackHelper;
 
 import org.bukkit.block.Block;
+import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
+import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
+import org.bukkit.event.hanging.HangingBreakEvent;
+import org.bukkit.event.hanging.HangingPlaceEvent;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Listener for entity events logged by the rollback engine.
@@ -44,17 +53,65 @@ import org.bukkit.event.entity.EntityExplodeEvent;
  */
 public class RollbackEntityListener implements Listener {
 
+    private static final List<EntityType> SUPPORTED_TYPES = new ArrayList<EntityType>();
+
+    static {
+        SUPPORTED_TYPES.add(EntityType.ARMOR_STAND);
+        SUPPORTED_TYPES.add(EntityType.ITEM_FRAME);
+        SUPPORTED_TYPES.add(EntityType.LEASH_HITCH);
+        SUPPORTED_TYPES.add(EntityType.PAINTING);
+    }
+
+    // BLOCK ROLLBACKS
+
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onEntityExplode(EntityExplodeEvent event) {
         for (Block b : event.blockList()) {
-            RollbackHelper.checkBlockChange(b.getLocation(), b.getState());
+            RollbackHelper.checkBlockChange(b.getLocation(), b.getState(), event);
         }
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     // covers enderman, falling blocks, and probably other stuff I'm forgetting
     public void onEntityChangeBlock(EntityChangeBlockEvent event) {
-        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState());
+        RollbackHelper.checkBlockChange(event.getBlock().getLocation(), event.getBlock().getState(), event);
+    }
+
+    // ENTITY ROLLBACKS
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onCreatureSpawn(CreatureSpawnEvent event) {
+        if (SUPPORTED_TYPES.contains(event.getEntity().getType())) {
+            RollbackHelper.checkEntityChange(event.getEntity(), true, event);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onEntityDeath(EntityDeathEvent event) {
+        if (SUPPORTED_TYPES.contains(event.getEntity().getType())) {
+            RollbackHelper.checkEntityChange(event.getEntity(), true, event);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onPlayerInteractEntity(PlayerInteractEntityEvent event) {
+        if (SUPPORTED_TYPES.contains(event.getRightClicked().getType())) {
+            RollbackHelper.checkEntityChange(event.getRightClicked(), true, event);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onHangingPlace(HangingPlaceEvent event) {
+        if (SUPPORTED_TYPES.contains(event.getEntity().getType())) {
+            RollbackHelper.checkEntityChange(event.getEntity(), true, event);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onHangingBreak(HangingBreakEvent event) {
+        if (SUPPORTED_TYPES.contains(event.getEntity().getType())) {
+            RollbackHelper.checkEntityChange(event.getEntity(), true, event);
+        }
     }
 
 }

--- a/src/main/java/net/caseif/flint/steel/listener/rollback/RollbackInventoryListener.java
+++ b/src/main/java/net/caseif/flint/steel/listener/rollback/RollbackInventoryListener.java
@@ -31,6 +31,7 @@ package net.caseif.flint.steel.listener.rollback;
 import net.caseif.flint.steel.util.helper.RollbackHelper;
 
 import org.bukkit.block.BlockState;
+import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -48,24 +49,24 @@ public class RollbackInventoryListener implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onInventoryClick(InventoryInteractEvent event) {
-        checkInventoryEvent(event.getInventory());
+        checkInventoryEvent(event.getInventory(), event);
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onInventoryClick(InventoryPickupItemEvent event) {
-        checkInventoryEvent(event.getInventory());
+        checkInventoryEvent(event.getInventory(), event);
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onInventoryClick(InventoryMoveItemEvent event) {
-        checkInventoryEvent(event.getSource());
-        checkInventoryEvent(event.getDestination());
+        checkInventoryEvent(event.getSource(), event);
+        checkInventoryEvent(event.getDestination(), event);
     }
 
-    public void checkInventoryEvent(Inventory inventory) {
+    public void checkInventoryEvent(Inventory inventory, Event event) {
         if (inventory.getHolder() instanceof BlockState) {
             BlockState bs = ((BlockState) inventory.getHolder());
-            RollbackHelper.checkBlockChange(bs.getLocation(), bs);
+            RollbackHelper.checkBlockChange(bs.getLocation(), bs, event);
         }
     }
 

--- a/src/main/java/net/caseif/flint/steel/util/PlayerUtil.java
+++ b/src/main/java/net/caseif/flint/steel/util/PlayerUtil.java
@@ -93,6 +93,7 @@ public class PlayerUtil {
      *     storage
      * @throws InvalidConfigurationException If the stored inventory is invalid
      */
+    //TODO: generalize some of this code for use with rollback storage
     public static void popInventory(Player player) throws IllegalArgumentException, IOException,
             InvalidConfigurationException {
         // the file to load the inventory from

--- a/src/main/java/net/caseif/flint/steel/util/helper/BlockStateSerializer.java
+++ b/src/main/java/net/caseif/flint/steel/util/helper/BlockStateSerializer.java
@@ -1,0 +1,204 @@
+package net.caseif.flint.steel.util.helper;
+
+import net.caseif.flint.steel.SteelCore;
+
+import com.google.common.base.Optional;
+import org.bukkit.DyeColor;
+import org.bukkit.Material;
+import org.bukkit.Note;
+import org.bukkit.block.Banner;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.CommandBlock;
+import org.bukkit.block.CreatureSpawner;
+import org.bukkit.block.Jukebox;
+import org.bukkit.block.NoteBlock;
+import org.bukkit.block.Sign;
+import org.bukkit.block.Skull;
+import org.bukkit.block.banner.Pattern;
+import org.bukkit.block.banner.PatternType;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.EntityType;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.material.FlowerPot;
+import org.bukkit.material.MaterialData;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Static utility class for serialization of block entity data.
+ *
+ * @author Max Roncacé
+ */
+public class BlockStateSerializer {
+
+    private static final String INVENTORY_KEY = "inventory";
+
+    private static final String SIGN_LINES_KEY = "lines";
+
+    private static final String BANNER_BASE_COLOR_KEY = "base-color";
+    private static final String BANNER_PATTERNS_KEY = "patterns";
+    private static final String BANNER_PATTERN_COLOR_KEY = "color";
+    private static final String BANNER_PATTERN_TYPE_KEY = "type";
+
+    private static final String SPAWNER_TYPE_KEY = "spawner-type";
+    private static final String SPAWNER_DELAY_KEY = "spawner-delay";
+
+    private static final String NOTE_OCTAVE_KEY = "octave";
+    private static final String NOTE_TONE_KEY = "tone";
+    private static final String NOTE_SHARPED_KEY = "sharped";
+
+    private static final String JUKEBOX_DISC_KEY = "disc";
+
+    private static final String SKULL_OWNER_KEY = "owner";
+    private static final String SKULL_ROTATION_KEY = "rotation";
+
+    private static final String COMMAND_NAME_KEY = "cmd-name";
+    private static final String COMMAND_CMD_KEY = "command";
+
+    private static final String FLOWER_TYPE_KEY = "flower-type";
+    private static final String FLOWER_DATA_KEY = "flower-data";
+
+    @SuppressWarnings("deprecation")
+    public static Optional<ConfigurationSection> serializeState(BlockState state) {
+        ConfigurationSection cs = new YamlConfiguration().createSection("thank mr skeltal");
+
+        // http://minecraft.gamepedia.com/Block_entity was used as a reference for this method
+
+        if (state instanceof InventoryHolder) {
+            cs.set(INVENTORY_KEY, InventoryHelper.serializeInventory(((InventoryHolder) state).getInventory()));
+        }
+
+        if (state instanceof Sign) {
+            cs.set(SIGN_LINES_KEY, Arrays.asList(((Sign) state).getLines()));
+        } else if (state instanceof Banner) {
+            cs.set(BANNER_BASE_COLOR_KEY, ((Banner) state).getBaseColor().name());
+            ConfigurationSection patternSection = cs.createSection(BANNER_PATTERNS_KEY);
+            List<Pattern> patterns = ((Banner) state).getPatterns();
+            for (int i = 0; i < patterns.size(); i++) {
+                ConfigurationSection subSection = patternSection.createSection("" + i);
+                subSection.set(BANNER_PATTERN_COLOR_KEY, patterns.get(i).getColor().name());
+                subSection.set(BANNER_PATTERN_TYPE_KEY, patterns.get(i).getPattern().name());
+            }
+        } else if (state instanceof CreatureSpawner) {
+            cs.set(SPAWNER_TYPE_KEY, ((CreatureSpawner) state).getSpawnedType().name());
+            cs.set(SPAWNER_DELAY_KEY, ((CreatureSpawner) state).getDelay());
+        } else if (state instanceof NoteBlock) {
+            cs.set(NOTE_OCTAVE_KEY, ((NoteBlock) state).getNote().getOctave());
+            cs.set(NOTE_TONE_KEY, ((NoteBlock) state).getNote().getTone().name());
+        } else if (state instanceof Jukebox) {
+            if (((Jukebox) state).isPlaying()) {
+                cs.set(JUKEBOX_DISC_KEY, ((Jukebox) state).getPlaying());
+            }
+        }
+        else if (state instanceof Skull) {
+            cs.set(SKULL_OWNER_KEY, ((Skull) state).getOwner());
+            cs.set(SKULL_ROTATION_KEY, ((Skull) state).getRotation().name());
+        } else if (state instanceof CommandBlock) {
+            cs.set(COMMAND_NAME_KEY, ((CommandBlock) state).getName());
+            cs.set(COMMAND_CMD_KEY, ((CommandBlock) state).getCommand());
+        } else if (state instanceof FlowerPot) {
+            cs.set(FLOWER_TYPE_KEY, ((FlowerPot) state).getContents().getItemType().name());
+            cs.set(FLOWER_DATA_KEY, ((FlowerPot) state).getContents().getData());
+        }
+
+        if (cs.getKeys(false).size() > 0) {
+            return Optional.of(cs);
+        } else {
+            return Optional.absent();
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    public static void deserializeState(Block block, ConfigurationSection serial) {
+        BlockState state = block.getState();
+
+        if (state instanceof InventoryHolder) {
+            if (serial.isConfigurationSection(INVENTORY_KEY)) {
+                ((InventoryHolder) state).getInventory().setContents(
+                        InventoryHelper.deserializeInventory(serial.getConfigurationSection(INVENTORY_KEY))
+                );
+            }
+        }
+
+        if (state instanceof Sign) {
+            if (serial.isList(SIGN_LINES_KEY)) {
+                List<String> lines = serial.getStringList(SIGN_LINES_KEY);
+                for (int i = 0; i < lines.size(); i++) {
+                    ((Sign) state).setLine(i, lines.get(i));
+                }
+            } //TODO: else: verbose logging
+        } else if (state instanceof Banner) {
+            if (serial.isSet(BANNER_BASE_COLOR_KEY)) {
+                DyeColor color = DyeColor.valueOf(serial.getString(BANNER_BASE_COLOR_KEY));
+                if (color != null) {
+                    ((Banner) state).setBaseColor(color);
+                } //TODO: else: verbose logging
+            } //TODO: else: verbose logging
+            if (serial.isConfigurationSection(BANNER_PATTERNS_KEY)) {
+                ConfigurationSection patterns = serial.getConfigurationSection(BANNER_PATTERNS_KEY);
+                for (String key : patterns.getKeys(false)) {
+                    ConfigurationSection subSection = patterns.getConfigurationSection(key);
+                    DyeColor color = DyeColor.valueOf(subSection.getString(BANNER_PATTERN_COLOR_KEY));
+                    PatternType type = PatternType.valueOf(subSection.getString(BANNER_PATTERN_TYPE_KEY));
+                    if (color != null && type != null) {
+                        ((Banner) state).addPattern(new Pattern(color, type));
+                    } //TODO: else: verbose logging
+                }
+            } //TODO: else: verbose logging
+        } else if (state instanceof CreatureSpawner) {
+            if (serial.isSet(SPAWNER_TYPE_KEY)) {
+                EntityType type = EntityType.valueOf(serial.getString(SPAWNER_TYPE_KEY));
+                if (type != null) {
+                    ((CreatureSpawner) state).setSpawnedType(type);
+                } //TODO: else: verbose logging
+            } //TODO: else: verbose logging
+        } else if (state instanceof NoteBlock) {
+            if (serial.isInt(NOTE_OCTAVE_KEY) && serial.isSet(NOTE_TONE_KEY)) {
+                Note.Tone tone = Note.Tone.valueOf(serial.getString(NOTE_TONE_KEY));
+                if (tone != null) {
+                    ((NoteBlock) state).setNote(
+                            new Note(serial.getInt(NOTE_OCTAVE_KEY), tone, serial.getBoolean(NOTE_SHARPED_KEY))
+                    );
+                } //TODO: else: verbose logging
+            } //TODO: else: verbose logging
+        } else if (state instanceof Jukebox) {
+            if (serial.isSet(JUKEBOX_DISC_KEY)) {
+                Material disc = Material.valueOf(serial.getString(JUKEBOX_DISC_KEY));
+                if (disc != null) {
+                    ((Jukebox) state).setPlaying(disc);
+                } //TODO: else: verbose logging
+            } //TODO: else: verbose logging
+        } else if (state instanceof Skull) {
+            if (serial.isSet(SKULL_OWNER_KEY)) {
+                ((Skull) state).setOwner(serial.getString(SKULL_OWNER_KEY));
+            } //TODO: else: verbose logging
+            if (serial.isSet(SKULL_ROTATION_KEY)) {
+                BlockFace face = BlockFace.valueOf(serial.getString(SKULL_ROTATION_KEY));
+                if (face != null) {
+                    ((Skull) state).setRotation(face);
+                }
+            } //TODO: else: verbose logging
+        } else if (state instanceof CommandBlock) {
+            if (serial.isSet(COMMAND_CMD_KEY)) {
+                ((CommandBlock) state).setCommand(serial.getString(COMMAND_CMD_KEY));
+            } //TODO: else: verbose logging
+            if (serial.isSet(COMMAND_NAME_KEY)) {
+                ((CommandBlock) state).setName(serial.getString(COMMAND_NAME_KEY));
+            }
+        } else if (state instanceof FlowerPot) {
+            if (serial.isSet(FLOWER_TYPE_KEY)) {
+                Material type = Material.valueOf(serial.getString(FLOWER_TYPE_KEY));
+                byte data = serial.isSet(FLOWER_DATA_KEY) ? (byte) serial.getInt(FLOWER_DATA_KEY) : 0x0;
+                ((FlowerPot) state).setContents(new MaterialData(type, data));
+            } //TODO: else: verbose logging
+        } else if (!(state instanceof InventoryHolder)){
+            SteelCore.logWarning("Failed to deserialize state data for rollback record for block at {"
+                    + block.getX() + ", " + block.getY() + ", " + block.getZ() + "}");
+        }
+    }
+
+}

--- a/src/main/java/net/caseif/flint/steel/util/helper/BlockStateSerializer.java
+++ b/src/main/java/net/caseif/flint/steel/util/helper/BlockStateSerializer.java
@@ -1,3 +1,31 @@
+/*
+ * New BSD License (BSD-new)
+ *
+ * Copyright (c) 2015 Maxim Roncacé
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     - Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     - Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     - Neither the name of the copyright holder nor the names of its contributors
+ *       may be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package net.caseif.flint.steel.util.helper;
 
 import net.caseif.flint.steel.SteelCore;
@@ -29,7 +57,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Static utility class for serialization of block entity data.
+ * Static utility class for serialization of block entity state.
  *
  * @author Max Roncacé
  */
@@ -93,8 +121,7 @@ public class BlockStateSerializer {
             if (((Jukebox) state).isPlaying()) {
                 cs.set(JUKEBOX_DISC_KEY, ((Jukebox) state).getPlaying());
             }
-        }
-        else if (state instanceof Skull) {
+        } else if (state instanceof Skull) {
             cs.set(SKULL_OWNER_KEY, ((Skull) state).getOwner());
             cs.set(SKULL_ROTATION_KEY, ((Skull) state).getRotation().name());
         } else if (state instanceof CommandBlock) {
@@ -233,7 +260,7 @@ public class BlockStateSerializer {
             } else {
                 missingData = true;
             }
-        } else if (!(state instanceof InventoryHolder)){
+        } else if (!(state instanceof InventoryHolder)) {
             SteelCore.logWarning("Failed to deserialize state data for rollback record for block at {"
                     + block.getX() + ", " + block.getY() + ", " + block.getZ() + "}");
         }

--- a/src/main/java/net/caseif/flint/steel/util/helper/EntityStateSerializer.java
+++ b/src/main/java/net/caseif/flint/steel/util/helper/EntityStateSerializer.java
@@ -1,0 +1,178 @@
+/*
+ * New BSD License (BSD-new)
+ *
+ * Copyright (c) 2015 Maxim Roncacé
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     - Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     - Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     - Neither the name of the copyright holder nor the names of its contributors
+ *       may be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.caseif.flint.steel.util.helper;
+
+import net.caseif.flint.steel.SteelCore;
+
+import org.bukkit.Art;
+import org.bukkit.Rotation;
+import org.bukkit.block.BlockFace;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Hanging;
+import org.bukkit.entity.ItemFrame;
+import org.bukkit.entity.Painting;
+import org.bukkit.util.EulerAngle;
+
+/**
+ * Static utility class for serialization of entity state.
+ *
+ * @author Max Roncacé
+ */
+public class EntityStateSerializer {
+
+    private static final String ARMOR_STAND_HELMET = "stand.helmet";
+    private static final String ARMOR_STAND_CHESTPLATE = "stand.chestplate";
+    private static final String ARMOR_STAND_LEGGINGS = "stand.leggings";
+    private static final String ARMOR_STAND_BOOTS = "stand.boots";
+    private static final String ARMOR_STAND_HAND = "stand.hand";
+    private static final String ARMOR_STAND_POSE_HEAD = "stand.pose.head";
+    private static final String ARMOR_STAND_POSE_BODY = "stand.pose.body";
+    private static final String ARMOR_STAND_POSE_ARM_LEFT = "stand.pose.arm_left";
+    private static final String ARMOR_STAND_POSE_ARM_RIGHT = "stand.pose.arm.right";
+    private static final String ARMOR_STAND_POSE_LEG_LEFT = "stand.pose.leg.left";
+    private static final String ARMOR_STAND_POSE_LEG_RIGHT = "stand.pose.leg.right";
+    private static final String ARMOR_STAND_ARMS = "stand.arms";
+    private static final String ARMOR_STAND_BASE_PLATE = "stand.base_plate";
+    private static final String ARMOR_STAND_GRAVITY = "stand.gravity";
+    private static final String ARMOR_STAND_SMALL = "stand.small";
+    private static final String ARMOR_STAND_VISIBLE = "stand.visible";
+
+    private static final String HANGING_FACING = "facing";
+
+    private static final String ITEM_FRAME_ITEM = "item";
+    private static final String ITEM_FRAME_ROTATION = "rotation";
+
+    private static final String PAINTING_ART = "art";
+
+    public static ConfigurationSection serializeState(Entity entity) {
+        ConfigurationSection cs = new YamlConfiguration().createSection("thank 4 good bones and calsium");
+
+        if (entity instanceof ArmorStand) {
+            ArmorStand stand = (ArmorStand) entity;
+            cs.set(ARMOR_STAND_HELMET, stand.getHelmet());
+            cs.set(ARMOR_STAND_CHESTPLATE, stand.getChestplate());
+            cs.set(ARMOR_STAND_LEGGINGS, stand.getLeggings());
+            cs.set(ARMOR_STAND_BOOTS, stand.getBoots());
+            cs.set(ARMOR_STAND_HAND, stand.getItemInHand());
+            cs.set(ARMOR_STAND_POSE_HEAD, serializeEulerAngle(stand.getHeadPose()));
+            cs.set(ARMOR_STAND_POSE_BODY, serializeEulerAngle(stand.getBodyPose()));
+            cs.set(ARMOR_STAND_POSE_ARM_LEFT, serializeEulerAngle(stand.getLeftArmPose()));
+            cs.set(ARMOR_STAND_POSE_ARM_RIGHT, serializeEulerAngle(stand.getRightArmPose()));
+            cs.set(ARMOR_STAND_POSE_LEG_LEFT, serializeEulerAngle(stand.getLeftLegPose()));
+            cs.set(ARMOR_STAND_POSE_LEG_RIGHT, serializeEulerAngle(stand.getRightLegPose()));
+            cs.set(ARMOR_STAND_ARMS, stand.hasArms());
+            cs.set(ARMOR_STAND_BASE_PLATE, stand.hasBasePlate());
+            cs.set(ARMOR_STAND_GRAVITY, stand.hasGravity());
+            cs.set(ARMOR_STAND_SMALL, stand.isSmall());
+            cs.set(ARMOR_STAND_VISIBLE, stand.isVisible());
+        } else if (entity instanceof Hanging) {
+            cs.set(HANGING_FACING, ((Hanging) entity).getFacing().name());
+            if (entity instanceof ItemFrame) {
+                cs.set(ITEM_FRAME_ITEM, ((ItemFrame) entity).getItem());
+                cs.set(ITEM_FRAME_ROTATION, ((ItemFrame) entity).getRotation().name());
+            } else if (entity instanceof Painting) {
+                cs.set(PAINTING_ART, ((Painting) entity).getArt().name());
+            }
+        }
+
+        return cs;
+    }
+
+    public static void deserializeState(Entity entity, ConfigurationSection serial) {
+        if (entity instanceof ArmorStand) {
+            ArmorStand stand = (ArmorStand) entity;
+            stand.setHelmet(serial.getItemStack(ARMOR_STAND_HELMET));
+            stand.setChestplate(serial.getItemStack(ARMOR_STAND_CHESTPLATE));
+            stand.setLeggings(serial.getItemStack(ARMOR_STAND_LEGGINGS));
+            stand.setBoots(serial.getItemStack(ARMOR_STAND_BOOTS));
+            stand.setItemInHand(serial.getItemStack(ARMOR_STAND_HAND));
+            stand.setHeadPose(deserializeEulerAngle(serial.getString(ARMOR_STAND_POSE_HEAD)));
+            stand.setBodyPose(deserializeEulerAngle(serial.getString(ARMOR_STAND_POSE_BODY)));
+            stand.setLeftArmPose(deserializeEulerAngle(serial.getString(ARMOR_STAND_POSE_ARM_LEFT)));
+            stand.setRightArmPose(deserializeEulerAngle(serial.getString(ARMOR_STAND_POSE_ARM_RIGHT)));
+            stand.setLeftLegPose(deserializeEulerAngle(serial.getString(ARMOR_STAND_POSE_LEG_LEFT)));
+            stand.setRightLegPose(deserializeEulerAngle(serial.getString(ARMOR_STAND_POSE_LEG_RIGHT)));
+            stand.setArms(serial.getBoolean(ARMOR_STAND_ARMS));
+            stand.setBasePlate(serial.getBoolean(ARMOR_STAND_BASE_PLATE));
+            stand.setGravity(serial.getBoolean(ARMOR_STAND_GRAVITY));
+            stand.setSmall(serial.getBoolean(ARMOR_STAND_SMALL));
+            stand.setVisible(serial.getBoolean(ARMOR_STAND_VISIBLE));
+        } else if (entity instanceof Hanging) {
+            BlockFace facing = BlockFace.valueOf(serial.getString(HANGING_FACING));
+            if (facing != null) {
+                ((Hanging) entity).setFacingDirection(facing);
+            } else {
+                SteelCore.logVerbose("Invalid serialized BlockFace value for hanging entity with UUID "
+                        + entity.getUniqueId().toString());
+            }
+            if (entity instanceof ItemFrame) {
+                ((ItemFrame) entity).setItem(serial.getItemStack(ITEM_FRAME_ITEM));
+                Rotation rotation = Rotation.valueOf(serial.getString(ITEM_FRAME_ROTATION));
+                // rotation doesn't sound like a word anymore
+                if (rotation != null) {
+                    ((ItemFrame) entity).setRotation(rotation);
+                } else {
+                    SteelCore.logVerbose("Invalid serialized Rotation value for item frame with UUID "
+                            + entity.getUniqueId().toString());
+                }
+            } else if (entity instanceof Painting) {
+                Art art = Art.valueOf(serial.getString("art"));
+                if (art != null) {
+                    ((Painting) entity).setArt(art);
+                } else {
+                    SteelCore.logVerbose("Invalid serialized Art value for item frame with UUID "
+                            + entity.getUniqueId().toString());
+                }
+            }
+        }
+    }
+
+    private static String serializeEulerAngle(EulerAngle angle) {
+        return "{" + angle.getX() + "," + angle.getY() + "," + angle.getZ() + "}";
+    }
+
+    private static EulerAngle deserializeEulerAngle(String serial) throws IllegalArgumentException {
+        if (serial.startsWith("{") && serial.endsWith("}")) {
+            String[] arr = serial.substring(1, serial.length() - 1).split(",");
+            if (arr.length == 3) {
+                try {
+                    double x = Double.parseDouble(arr[0]);
+                    double y = Double.parseDouble(arr[0]);
+                    double z = Double.parseDouble(arr[0]);
+                    return new EulerAngle(x, y, z);
+                } catch (NumberFormatException ignored) { } // continue to the IllegalArgumentException at the bottom
+            }
+        }
+        throw new IllegalArgumentException("Invalid serial for EulerAngle");
+    }
+
+}

--- a/src/main/java/net/caseif/flint/steel/util/helper/InventoryHelper.java
+++ b/src/main/java/net/caseif/flint/steel/util/helper/InventoryHelper.java
@@ -1,0 +1,70 @@
+/*
+ * New BSD License (BSD-new)
+ *
+ * Copyright (c) 2015 Maxim Roncacé
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     - Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     - Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     - Neither the name of the copyright holder nor the names of its contributors
+ *       may be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.caseif.flint.steel.util.helper;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Static utility class for inventory-related functionality.
+ *
+ * @author Max Roncacé
+ */
+public class InventoryHelper {
+
+    public static ConfigurationSection serializeInventory(Inventory inventory) {
+        return serializeInventory(inventory.getContents());
+    }
+
+    public static ConfigurationSection serializeInventory(ItemStack[] contents) {
+        ConfigurationSection cs = new YamlConfiguration().createSection("doot doot");
+        cs.set("capacity", contents.length);
+        for (int i = 0; i < contents.length; i++) {
+            cs.set(Integer.toString(i), contents[i]);
+        }
+        return cs;
+    }
+
+    public static ItemStack[] deserializeInventory(ConfigurationSection serial) throws IllegalArgumentException {
+        if (!serial.contains("capacity")) {
+            throw new IllegalArgumentException("Serialized inventory is missing required element \"capacity\"");
+        }
+        int capacity = serial.getInt("capacity");
+        ItemStack[] contents = new ItemStack[capacity];
+        for (int i = 0; i < capacity; i++) {
+            if (serial.contains(Integer.toString(i))) {
+                contents[i] = serial.getItemStack(Integer.toString(i));
+            }
+        }
+        return contents;
+    }
+
+}

--- a/src/main/java/net/caseif/flint/steel/util/helper/RollbackHelper.java
+++ b/src/main/java/net/caseif/flint/steel/util/helper/RollbackHelper.java
@@ -1,0 +1,123 @@
+package net.caseif.flint.steel.util.helper;
+
+import net.caseif.flint.steel.arena.SteelArena;
+import net.caseif.flint.steel.util.io.DataFiles;
+
+import org.bukkit.Location;
+import org.bukkit.block.BlockState;
+
+import java.io.File;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/**
+ * Static helper class for rollback functionality.
+ *
+ * @author Max Roncacé
+ */
+public final class RollbackHelper {
+
+    public static final String ROLLBACK_STORE_BLOCK_TABLE = "blocks";
+
+    private SteelArena arena;
+
+    /**
+     * Creates a new {@link RollbackHelper} backing the given
+     * {@link SteelArena}.
+     *
+     * @param arena The {@link SteelArena} to be backed by the new
+     *     {@link RollbackHelper}
+     */
+    public RollbackHelper(SteelArena arena) {
+        this.arena = arena;
+    }
+
+    /**
+     * Returns the {@link SteelArena} associated with this
+     * {@link RollbackHelper}.
+     *
+     * @return The {@link SteelArena} associated with this
+     * {@link RollbackHelper}.
+     */
+    public SteelArena getArena() {
+        return arena;
+    }
+
+    /**
+     * Creates a rollback database for the arena backing this
+     * {@link RollbackHelper}.
+     *
+     * @throws IOException If an exception occurs while creating the database
+     *     file
+     * @throws SQLException If an exception occurs while manipulating the
+     *     database
+     */
+    public static void createRollbackDatabase(SteelArena arena) throws IOException, SQLException {
+        File file = new File(DataFiles.ROLLBACK_PROFILE_DIR.getFile(arena.getMinigame()), arena.getId() + ".db");
+        if (file.exists()) {
+            return;
+        }
+        //noinspection ResultOfMethodCallIgnored
+        file.createNewFile();
+        try (Connection conn = DriverManager.getConnection("jdbc:sqlite:" + file.getPath())) {
+            try (Statement st = conn.createStatement()) {
+                st.executeUpdate("CREATE TABLE IF NOT EXISTS `" + ROLLBACK_STORE_BLOCK_TABLE + "` ("
+                        + "`id` INTEGER NOT NULL PRIMARY KEY,"
+                        + "`world` VARCHAR"
+                        + "`x` INTEGER NOT NULL,"
+                        + "`y` INTEGER NOT NULL,"
+                        + "`z` INTEGER NOT NULL,"
+                        + "`type` VARCHAR(32) NOT NULL,"
+                        + "`data` INTEGER NOT NULL"
+                        + ")");
+            }
+        }
+    }
+
+    /**
+     * Logs a block change at the given location.
+     *
+     * @param location The location of the change
+     * @param originalState The state of the block before the change
+     * @throws IOException If an exception occurs while reading to or from the
+     *     rollback database
+     * @throws SQLException If an exception occurs while manipulating the
+     *     rollback database
+     */
+    @SuppressWarnings("deprecation")
+    public void logBlockChange(Location location, BlockState originalState)
+            throws IOException, SQLException {
+        File rollbackStore = new File(DataFiles.ARENA_STORE.getFile(getArena().getMinigame()), getArena().getId()
+                + ".db");
+        if (!rollbackStore.exists()) {
+            //noinspection ResultOfMethodCallIgnored
+            rollbackStore.createNewFile();
+        }
+        try (Connection conn = DriverManager.getConnection("jdbc:sqlite:" + rollbackStore.getPath())) {
+            Statement st = conn.createStatement();
+            try (ResultSet rs = st.executeQuery("SELECT * FROM `" + RollbackHelper.ROLLBACK_STORE_BLOCK_TABLE + "`"
+                    + " WHERE world='" + location.getWorld().getName() + "'"
+                    + " && x=" + location.getX()
+                    + " && y=" + location.getY()
+                    + " && z=" + location.getZ())) {
+                if (!rs.next()) { // if no results
+                    st.executeUpdate("INSERT INTO `" + ROLLBACK_STORE_BLOCK_TABLE + "` "
+                            + "(`world`, `x`, `y`, `z`, `type`, `data`) VALUES ("
+                            + "'" + location.getWorld().getName() + "',"
+                            + location.getBlockX() + ","
+                            + location.getBlockY() + ","
+                            + location.getBlockZ() + ","
+                            + "'" + originalState.getType().name() + "',"
+                            + originalState.getRawData()
+                            + ")");
+                    //TODO: store state in separate file
+                } // else: do nothing since it's already been changed from its original state
+            }
+        }
+    }
+
+}

--- a/src/main/java/net/caseif/flint/steel/util/helper/RollbackHelper.java
+++ b/src/main/java/net/caseif/flint/steel/util/helper/RollbackHelper.java
@@ -229,12 +229,22 @@ public final class RollbackHelper {
                                         BlockStateSerializer
                                                 .deserializeState(b, yaml.getConfigurationSection(getArena().getId()));
                                         yaml.set("" + id, null); // clear state log
-                                    } //TODO: else: verbose logging
+                                    } else {
+                                        SteelCore.logVerbose("Rollback record with ID " + id + " was marked as having "
+                                                + "block entity state, but no corresponding state configuration was "
+                                                + "found");
+                                    }
                                 }
-                            } //TODO: else: verbose logging
-                        } //TODO: else: verbose logging
+                            } else {
+                                SteelCore.logWarning("Rollback record with ID " + id + " in arena " + getArena().getId()
+                                        + " cannot be matched to a Material");
+                            }
+                        } else {
+                            SteelCore.logVerbose("Rollback record with ID " + id + " in arena " + getArena().getId()
+                                    + " has a mismtching world name - refusing to roll back");
+                        }
                     } catch (InvalidConfigurationException | IOException | SQLException ex) {
-                        SteelCore.logSevere("Failed to read rollback record");
+                        SteelCore.logSevere("Failed to read rollback record in arena " + getArena().getId());
                         ex.printStackTrace();
                     }
                 }

--- a/src/main/java/net/caseif/flint/steel/util/helper/RollbackHelper.java
+++ b/src/main/java/net/caseif/flint/steel/util/helper/RollbackHelper.java
@@ -36,6 +36,7 @@ import net.caseif.flint.steel.util.MiscUtil;
 import net.caseif.flint.steel.util.io.DataFiles;
 
 import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -45,6 +46,9 @@ import org.bukkit.block.BlockState;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.event.Event;
 
 import java.io.File;
 import java.io.IOException;
@@ -55,7 +59,9 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.HashMap;
 import java.util.Properties;
+import java.util.UUID;
 
 /**
  * Helper class for rollback functionality.
@@ -64,13 +70,17 @@ import java.util.Properties;
  */
 public final class RollbackHelper {
 
-    public static final String ROLLBACK_STORE_BLOCK_TABLE = "blocks";
     public static final String SQLITE_PROTOCOL = "jdbc:sqlite:";
     public static final Properties SQL_QUERIES = new Properties();
 
+    private static final int RECORD_TYPE_BLOCK_CHANGED = 0;
+    private static final int RECORD_TYPE_ENTITY_CREATED = 1;
+    private static final int RECORD_TYPE_ENTITY_CHANGED = 2;
+
+    private File rollbackStore = DataFiles.ROLLBACK_STORE.getFile(getArena().getMinigame());
+    private File stateStore = DataFiles.ROLLBACK_STATE_STORE.getFile(getArena().getMinigame());
+
     private SteelArena arena;
-    private File rollbackStore = new File(DataFiles.ARENA_STORE.getFile(getArena().getMinigame()),
-            getArena().getId().concat(".db"));
 
     static {
         try (InputStream is = RollbackHelper.class.getResourceAsStream("sql-queries.properties")) {
@@ -120,7 +130,7 @@ public final class RollbackHelper {
         try (Connection conn = DriverManager.getConnection(SQLITE_PROTOCOL + rollbackStore.getAbsolutePath())) {
             try (
                     PreparedStatement st = conn.prepareStatement(SQL_QUERIES.getProperty("create-rollback-table")
-                            .replace("{table}", ROLLBACK_STORE_BLOCK_TABLE));
+                            .replace("{table}", getArena().getId()));
             ) {
                 st.executeUpdate();
             }
@@ -142,53 +152,139 @@ public final class RollbackHelper {
     @SuppressWarnings("deprecation")
     public void logBlockChange(Location location, BlockState originalState)
             throws InvalidConfigurationException, IOException, SQLException {
+        ConfigurationSection state = BlockStateSerializer.serializeState(originalState).orNull();
+        logChange(RECORD_TYPE_BLOCK_CHANGED, location, null, originalState.getType().name(), originalState.getRawData(),
+                state);
+    }
+
+    public void logEntityCreation(Entity entity) throws InvalidConfigurationException, IOException, SQLException {
+        logEntitySomething(entity, true);
+    }
+
+    public void logEntityChange(Entity entity) throws InvalidConfigurationException, IOException, SQLException {
+        logEntitySomething(entity, false);
+    }
+
+    private void logEntitySomething(Entity entity, boolean newlyCreated)
+            throws InvalidConfigurationException, IOException, SQLException {
+        ConfigurationSection state = !newlyCreated ? EntityStateSerializer.serializeState(entity) : null;
+        logChange(newlyCreated ? RECORD_TYPE_ENTITY_CREATED : RECORD_TYPE_ENTITY_CHANGED, entity.getLocation(),
+                entity.getUniqueId(), entity.getType().name(), -1, state);
+    }
+
+    private void logChange(int recordType, Location location, UUID uuid, String type, int data,
+                           ConfigurationSection state) throws InvalidConfigurationException, IOException, SQLException {
+        Preconditions.checkNotNull(location, "Location required for all record types");
+        switch (recordType) {
+            case RECORD_TYPE_BLOCK_CHANGED:
+                Preconditions.checkNotNull(type, "Type required for BLOCK_CHANGED record type");
+                break;
+            case RECORD_TYPE_ENTITY_CREATED:
+                Preconditions.checkNotNull(uuid, "UUID required for ENTITY_CREATED record type");
+                Preconditions.checkNotNull(type, "Type required for ENTITY_CREATED record type");
+                break;
+            case RECORD_TYPE_ENTITY_CHANGED:
+                Preconditions.checkNotNull(type, "Type required for ENTITY_CHANGED record type");
+                Preconditions.checkNotNull(state, "State required for ENTITY_CHANGED record type");
+                break;
+            default:
+                throw new IllegalArgumentException("Undefined record type");
+        }
         if (!rollbackStore.exists()) {
             //noinspection ResultOfMethodCallIgnored
             rollbackStore.createNewFile();
         }
         try (
                 Connection conn = DriverManager.getConnection("jdbc:sqlite:" + rollbackStore.getPath());
-                Statement st = conn.createStatement();
         ) {
-            try (ResultSet rs = st.executeQuery(SQL_QUERIES.getProperty("query-rollback-table")
+            String querySql;
+            switch (recordType) {
+                case RECORD_TYPE_BLOCK_CHANGED:
+                    querySql = SQL_QUERIES.getProperty("query-by-location")
+                            .replace("{world}", location.getWorld().getName())
+                            .replace("{x}", "" + location.getBlockX())
+                            .replace("{y}", "" + location.getBlockY())
+                            .replace("{z}", "" + location.getBlockZ());
+                    break;
+                case RECORD_TYPE_ENTITY_CHANGED:
+                    querySql = SQL_QUERIES.getProperty("query-by-uuid")
+                            .replace("{uuid}", uuid.toString());
+                    break;
+                default:
+                    querySql = null;
+                    break;
+            }
+            if (querySql != null) {
+                querySql = querySql.replace("{table}", getArena().getId());
+                try (
+                        PreparedStatement query = conn.prepareStatement(querySql);
+                        ResultSet queryResults = query.executeQuery();
+                ) {
+                    if (queryResults.next()) {
+                        return; // subject has already been modified; no need to re-record
+                    }
+                }
+            }
+
+            String updateSql;
+            switch (recordType) {
+                case RECORD_TYPE_BLOCK_CHANGED:
+                    updateSql = SQL_QUERIES.getProperty("insert-block-rollback-record")
                             .replace("{world}", location.getWorld().getName())
                             .replace("{x}", "" + location.getBlockX())
                             .replace("{y}", "" + location.getBlockY())
                             .replace("{z}", "" + location.getBlockZ())
-            )) {
-                if (!rs.next()) { // if no results
-                    Optional<ConfigurationSection> state = BlockStateSerializer.serializeState(originalState);
-                    st.executeUpdate(SQL_QUERIES.getProperty("insert-rollback-record")
-                                    .replace("{world}", location.getWorld().getName())
-                                    .replace("{x}", "" + location.getBlockX())
-                                    .replace("{y}", "" + location.getBlockY())
-                                    .replace("{z}", "" + location.getBlockZ())
-                                    .replace("{type}", originalState.getType().name())
-                                    .replace("{data}", "" + originalState.getRawData())
-                                    .replace("{state}", "" + (state.isPresent() ? 1 : 0)),
-                            Statement.RETURN_GENERATED_KEYS);
-                    if (state.isPresent()) {
-                        try (ResultSet gen = st.getGeneratedKeys()) {
-                            if (gen.next()) {
-                                int id = gen.getInt(1);
-                                File stateStore = new File(
-                                        DataFiles.ROLLBACK_STATE_DIR.getFile(getArena().getMinigame()),
-                                        getArena().getId().concat(".yml"));
-                                YamlConfiguration yaml = new YamlConfiguration();
-                                yaml.load(stateStore);
-                                if (yaml.isSet(Integer.toString(id))) {
-                                    throw new IllegalStateException("Tried to store state with id " + id + ", but "
-                                            + "index was already present in rollback store! Something's gone terribly "
-                                            + "wrong."); // technically should never happen but you never know
-                                }
-                                yaml.set(Integer.toString(id), state.get());
-                                yaml.save(stateStore);
-                            } else {
-                                throw new SQLException("Failed to get generated key from INSERT query");
-                            }
-                        }
-                    }
-                } // else: do nothing since it's already been changed from its original state
+                            .replace("{type}", type)
+                            .replace("{data}", "" + data);
+                    break;
+                case RECORD_TYPE_ENTITY_CREATED:
+                    updateSql = SQL_QUERIES.getProperty("insert-entity-created-rollback-record")
+                            .replace("{world}", location.getWorld().getName())
+                            .replace("{uuid}", uuid.toString());
+                    break;
+                case RECORD_TYPE_ENTITY_CHANGED:
+                    updateSql = SQL_QUERIES.getProperty("insert-entity-changed-rollback-record")
+                            .replace("{world}", location.getWorld().getName())
+                            .replace("{x}", "" + location.getBlockX())
+                            .replace("{y}", "" + location.getBlockY())
+                            .replace("{z}", "" + location.getBlockZ())
+                            .replace("{uuid}", uuid.toString())
+                            .replace("{type}", type);
+                    break;
+                default:
+                    throw new AssertionError("Inconsistency detected in method: recordType is in an illegal state");
+            }
+            if (updateSql != null) {
+                // replace non-negotiable values
+                updateSql = updateSql
+                        .replace("{table}", getArena().getId())
+                        .replace("{state}", "" + (state != null))
+                        .replace("{record_type}", "" + recordType);
+            }
+            int id;
+            try (
+                    PreparedStatement ps = conn.prepareStatement(updateSql, Statement.RETURN_GENERATED_KEYS);
+                    ResultSet gen = ps.getGeneratedKeys();
+            ) {
+                if (gen.next()) {
+                    id = gen.getInt(1);
+                } else {
+                    throw new SQLException("Failed to get generated key from update query");
+                }
+            }
+            if (state != null) {
+                YamlConfiguration yaml = new YamlConfiguration();
+                yaml.load(stateStore);
+                ConfigurationSection arenaSec = yaml.isConfigurationSection(getArena().getId())
+                        ? yaml.getConfigurationSection(getArena().getId())
+                        : yaml.createSection(getArena().getId());
+                if (arenaSec.isSet(Integer.toString(id))) {
+                    throw new IllegalStateException("Tried to store state with id " + id + ", but "
+                            + "index was already present in rollback store! Something's gone terribly "
+                            + "wrong."); // technically should never happen but you never know
+                }
+                arenaSec.set(Integer.toString(id), state);
+                yaml.save(stateStore);
             }
         }
     }
@@ -198,11 +294,18 @@ public final class RollbackHelper {
         if (rollbackStore.exists()) {
             try (
                     Connection conn = DriverManager.getConnection(SQLITE_PROTOCOL + rollbackStore.getAbsolutePath());
-                    PreparedStatement st = conn.prepareStatement(SQL_QUERIES.getProperty("get-all-rollbacks")
-                            .replace("{table}", ROLLBACK_STORE_BLOCK_TABLE));
+                    PreparedStatement st = conn.prepareStatement(SQL_QUERIES.getProperty("get-all-records")
+                            .replace("{table}", getArena().getId()));
                     ResultSet rs = st.executeQuery();
             ) {
                 World w = Bukkit.getWorld(getArena().getWorld());
+
+                // hash entities by UUID before iterating records for faster lookup
+                HashMap<UUID, Entity> entities = new HashMap<>();
+                for (Entity entity : w.getEntities()) {
+                    entities.put(entity.getUniqueId(), entity);
+                }
+
                 while (rs.next()) {
                     try {
                         int id = rs.getInt("id");
@@ -210,35 +313,64 @@ public final class RollbackHelper {
                         int x = rs.getInt("x");
                         int y = rs.getInt("y");
                         int z = rs.getInt("z");
+                        UUID uuid = UUID.fromString(rs.getString("uuid"));
                         String type = rs.getString("type");
                         int data = rs.getInt("data");
                         boolean state = rs.getBoolean("state");
+                        int recordType = rs.getInt("record_type");
+
                         if (world.equals(getArena().getWorld())) {
-                            Block b = w.getBlockAt(x, y, z);
-                            Material m = Material.valueOf(type);
-                            if (m != null) {
-                                b.setType(m);
-                                b.setData((byte) data);
-                                if (state) {
-                                    File stateStore = new File(
-                                            DataFiles.ROLLBACK_STATE_DIR.getFile(getArena().getMinigame()),
-                                            getArena().getId().concat(".yml"));
-                                    YamlConfiguration yaml = new YamlConfiguration();
-                                    yaml.load(stateStore);
-                                    if (yaml.isConfigurationSection("" + id)) {
-                                        BlockStateSerializer
-                                                .deserializeState(b, yaml.getConfigurationSection(getArena().getId()));
-                                        yaml.set("" + id, null); // clear state log
-                                    } else {
-                                        SteelCore.logVerbose("Rollback record with ID " + id + " was marked as having "
-                                                + "block entity state, but no corresponding state configuration was "
-                                                + "found");
-                                    }
+                            ConfigurationSection stateSerial = null;
+                            if (state) {
+                                YamlConfiguration yaml = new YamlConfiguration();
+                                yaml.load(stateStore);
+                                if (yaml.isConfigurationSection("" + id)) {
+                                    stateSerial = yaml.getConfigurationSection(getArena().getId());
+                                } else {
+                                    SteelCore.logVerbose("Rollback record with ID " + id + " was marked as having "
+                                            + "state, but no corresponding serial was found");
                                 }
-                            } else {
-                                SteelCore.logWarning("Rollback record with ID " + id + " in arena " + getArena().getId()
-                                        + " cannot be matched to a Material");
                             }
+
+                            switch (recordType) {
+                                case RECORD_TYPE_BLOCK_CHANGED:
+                                    Block b = w.getBlockAt(x, y, z);
+                                    Material m = Material.valueOf(type);
+                                    if (m != null) {
+                                        b.setType(m);
+                                        b.setData((byte) data);
+                                        if (stateSerial != null) {
+                                            BlockStateSerializer.deserializeState(b, stateSerial);
+                                        }
+                                    } else {
+                                        SteelCore.logWarning("Rollback record with ID " + id + " in arena "
+                                                + getArena().getId() + " cannot be matched to a Material");
+                                    }
+                                    break;
+                                case RECORD_TYPE_ENTITY_CREATED:
+                                    if (entities.containsKey(uuid)) {
+                                        entities.get(uuid).remove();
+                                    } // else: probably already removed by a player or something else
+                                    break;
+                                case RECORD_TYPE_ENTITY_CHANGED:
+                                    EntityType entityType = EntityType.valueOf(type);
+                                    if (entityType != null) {
+                                        if (entities.containsKey(uuid)) {
+                                            entities.get(uuid).remove(); // clean slate
+                                        }
+                                        Entity e = w.spawnEntity(new Location(w, x, y, z), entityType);
+                                        if (stateSerial != null) {
+                                            EntityStateSerializer.deserializeState(e, stateSerial);
+                                        }
+                                    } else {
+                                        SteelCore.logWarning("Invalid entity type for rollback record with ID " + id
+                                                + " in arena " + getArena().getId());
+                                    }
+                                    break;
+                                default:
+                                    SteelCore.logWarning("Invalid rollback record type at ID " + id);
+                            }
+
                         } else {
                             SteelCore.logVerbose("Rollback record with ID " + id + " in arena " + getArena().getId()
                                     + " has a mismtching world name - refusing to roll back");
@@ -251,25 +383,51 @@ public final class RollbackHelper {
             }
             //noinspection ResultOfMethodCallIgnored
             rollbackStore.delete();
+            //noinspection ResultOfMethodCallIgnored
+            stateStore.delete();
         } else {
             throw new IllegalArgumentException("Rollback store does not exist");
         }
     }
 
-    public static void checkBlockChange(Location location, BlockState originalState) {
+    private static Optional<Arena> checkChangeAtLocation(Location location) {
         for (Minigame mg : SteelCore.getMinigames().values()) {
             for (Arena arena : mg.getArenas()) {
                 if (arena.getWorld().equals(location.getWorld().getName())) {
                     if (arena.getBoundary().contains(
                             MiscUtil.convertLocation(location))) {
-                        try {
-                            ((SteelArena) arena).getRollbackHelper().logBlockChange(location, originalState);
-                        } catch (InvalidConfigurationException | IOException | SQLException ex) {
-                            throw new RuntimeException("Failed to log block change for rollback in arena "
-                                    + arena.getName(), ex);
-                        }
+                        return Optional.of(arena);
                     }
                 }
+            }
+        }
+        return Optional.absent();
+    }
+
+    public static void checkBlockChange(Location location, BlockState state, Event event) {
+        Optional<Arena> arena = checkChangeAtLocation(location);
+        if (arena.isPresent()) {
+            try {
+                ((SteelArena) arena.get()).getRollbackHelper().logBlockChange(location, state);
+            } catch (InvalidConfigurationException | IOException | SQLException ex) {
+                throw new RuntimeException("Failed to log " + event.getEventName() + " for rollback in arena "
+                        + arena.get().getName(), ex);
+            }
+        }
+    }
+
+    public static void checkEntityChange(Entity entity, boolean newlyCreated, Event event) {
+        Optional<Arena> arena = checkChangeAtLocation(entity.getLocation());
+        if (arena.isPresent()) {
+            try {
+                if (newlyCreated) {
+                    ((SteelArena) arena.get()).getRollbackHelper().logEntityCreation(entity);
+                } else {
+                    ((SteelArena) arena.get()).getRollbackHelper().logEntityChange(entity);
+                }
+            } catch (InvalidConfigurationException | IOException | SQLException ex) {
+                throw new RuntimeException("Failed to log " + event.getEventName() + " for rollback in arena "
+                        + arena.get().getName(), ex);
             }
         }
     }

--- a/src/main/java/net/caseif/flint/steel/util/helper/RollbackHelper.java
+++ b/src/main/java/net/caseif/flint/steel/util/helper/RollbackHelper.java
@@ -4,7 +4,6 @@ import net.caseif.flint.steel.arena.SteelArena;
 import net.caseif.flint.steel.util.io.DataFiles;
 
 import com.google.common.base.Optional;
-import org.apache.commons.lang3.NotImplementedException;
 import org.bukkit.Location;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
@@ -155,14 +154,15 @@ public final class RollbackHelper {
 
     private Optional<ConfigurationSection> serializeState(BlockState state) {
         if (state instanceof InventoryHolder) {
-            throw new NotImplementedException("TODO");
+            //TODO
         } else if (state instanceof Sign) {
-            throw new NotImplementedException("TODO");
+            //TODO
         } else if (state instanceof Skull) {
-            throw new NotImplementedException("TODO");
+            //TODO
         } else {
             return Optional.absent();
         }
+        throw new UnsupportedOperationException("Not yet implemented");
     }
 
 }

--- a/src/main/java/net/caseif/flint/steel/util/io/DataFiles.java
+++ b/src/main/java/net/caseif/flint/steel/util/io/DataFiles.java
@@ -49,6 +49,8 @@ public class DataFiles {
 
     public static final MinigameDataFile ARENA_STORE = new MinigameDataFile("arenas.yml");
     public static final MinigameDataFile ROLLBACK_PROFILE_DIR = new MinigameDataFile("rollbacks", true);
+    public static final MinigameDataFile ROLLBACK_STATE_DIR = new MinigameDataFile(
+            ROLLBACK_PROFILE_DIR.getFileName() + File.pathSeparatorChar + "state");
 
     static final List<DataFile> files = new ArrayList<>();
 

--- a/src/main/java/net/caseif/flint/steel/util/io/DataFiles.java
+++ b/src/main/java/net/caseif/flint/steel/util/io/DataFiles.java
@@ -48,9 +48,8 @@ public class DataFiles {
     public static final CoreDataFile PLAYER_LOCATION_STORE = new CoreDataFile("locs.yml");
 
     public static final MinigameDataFile ARENA_STORE = new MinigameDataFile("arenas.yml");
-    public static final MinigameDataFile ROLLBACK_PROFILE_DIR = new MinigameDataFile("rollbacks", true);
-    public static final MinigameDataFile ROLLBACK_STATE_DIR = new MinigameDataFile(
-            ROLLBACK_PROFILE_DIR.getFileName() + File.pathSeparatorChar + "state");
+    public static final MinigameDataFile ROLLBACK_STORE = new MinigameDataFile("rollback.db");
+    public static final MinigameDataFile ROLLBACK_STATE_STORE = new MinigameDataFile("rollback_state.yml");
 
     static final List<DataFile> files = new ArrayList<>();
 

--- a/src/main/java/net/caseif/flint/steel/util/io/DataFiles.java
+++ b/src/main/java/net/caseif/flint/steel/util/io/DataFiles.java
@@ -48,6 +48,7 @@ public class DataFiles {
     public static final CoreDataFile PLAYER_LOCATION_STORE = new CoreDataFile("locs.yml");
 
     public static final MinigameDataFile ARENA_STORE = new MinigameDataFile("arenas.yml");
+    public static final MinigameDataFile ROLLBACK_PROFILE_DIR = new MinigameDataFile("rollbacks", true);
 
     static final List<DataFile> files = new ArrayList<>();
 

--- a/src/main/resources/sql-queries.properties
+++ b/src/main/resources/sql-queries.properties
@@ -1,3 +1,4 @@
-create-rollback-table=CREATE TABLE IF NOT EXISTS `{table}` (`id` INTEGER NOT NULL PRIMARY KEY, `world` VARCHAR(128) NOT NULL, `x` INTEGER NOT NULL, `y` INTEGER NOT NULL, `z` INTEGER NOT NULL, `type` VARCHAR(32) NOT NULL, `data` INTEGER NOT NULL)
+create-rollback-table=CREATE TABLE IF NOT EXISTS `{table}` (`id` INTEGER NOT NULL PRIMARY KEY, `world` VARCHAR(128) NOT NULL, `x` INTEGER NOT NULL, `y` INTEGER NOT NULL, `z` INTEGER NOT NULL, `type` VARCHAR(32) NOT NULL, `data` INTEGER NOT NULL, `state` TINYINT NOT NULL)
 query-rollback-table=SELECT * FROM `{table}` WHERE `world`={world} AND `x`={x} AND y={y} AND z={z}
-insert-rollback-record=INSERT INTO `{table}` (`world`, `x`, `y`, `z`, `type`, `data`) VALUES ('{world}', {x}, {y}, {z}, '{type}', {data})
+insert-rollback-record=INSERT INTO `{table}` (`world`, `x`, `y`, `z`, `type`, `data`, `state`) VALUES ('{world}', {x}, {y}, {z}, '{type}', {data}, {state})
+get-all-rollbacks=SELECT * FROM `{table}`

--- a/src/main/resources/sql-queries.properties
+++ b/src/main/resources/sql-queries.properties
@@ -1,0 +1,3 @@
+create-rollback-table=CREATE TABLE IF NOT EXISTS `{table}` (`id` INTEGER NOT NULL PRIMARY KEY, `world` VARCHAR(128) NOT NULL, `x` INTEGER NOT NULL, `y` INTEGER NOT NULL, `z` INTEGER NOT NULL, `type` VARCHAR(32) NOT NULL, `data` INTEGER NOT NULL)
+query-rollback-table=SELECT * FROM `{table}` WHERE `world`={world} AND `x`={x} AND y={y} AND z={z}
+insert-rollback-record=INSERT INTO `{table}` (`world`, `x`, `y`, `z`, `type`, `data`) VALUES ('{world}', {x}, {y}, {z}, '{type}', {data})

--- a/src/main/resources/sql-queries.properties
+++ b/src/main/resources/sql-queries.properties
@@ -1,4 +1,9 @@
-create-rollback-table=CREATE TABLE IF NOT EXISTS `{table}` (`id` INTEGER NOT NULL PRIMARY KEY, `world` VARCHAR(128) NOT NULL, `x` INTEGER NOT NULL, `y` INTEGER NOT NULL, `z` INTEGER NOT NULL, `type` VARCHAR(32) NOT NULL, `data` INTEGER NOT NULL, `state` TINYINT NOT NULL)
-query-rollback-table=SELECT * FROM `{table}` WHERE `world`={world} AND `x`={x} AND y={y} AND z={z}
-insert-rollback-record=INSERT INTO `{table}` (`world`, `x`, `y`, `z`, `type`, `data`, `state`) VALUES ('{world}', {x}, {y}, {z}, '{type}', {data}, {state})
-get-all-rollbacks=SELECT * FROM `{table}`
+create-rollback-table=CREATE TABLE IF NOT EXISTS `{table}` (`id` INTEGER NOT NULL PRIMARY KEY, `world` VARCHAR(128) NOT NULL, `x` INTEGER, `y` INTEGER, `z` INTEGER, `uuid` VARCHAR(36), `type`s VARCHAR(32), `data` INTEGER, `state` TINYINT NOT NULL, `record_type` INTEGER NOT NULL)
+
+get-all-records=SELECT * FROM `{table}`
+query-by-location=SELECT * FROM `{table}` WHERE `world`={world} AND `x`={x} AND y={y} AND z={z}
+query-by-uuid=SELECT * FROM `{table}` WhERE uuid='{uuid}'
+
+insert-block-rollback-record=INSERT INTO `{table}` (`world`, `x`, `y`, `z`, `type`, `data`, `state`, `record_type`) VALUES ('{world}', {x}, {y}, {z}, '{type}', {data}, {state}, {record_type})
+insert-entity-created-rollback-record=INSERT INTO `{table}` (`world`, `uuid`, `state`, `record_type`) VALUES ('{uuid}', {state}, {record_type})
+insert-entity-changed-rollback-record=INSERT INTO `{table}` (`world`, `x`, `y`, `z`, `uuid`, `type`, `state`, `record_type`) VALUES ('{world}', {x}, {y}, {z}, '{uuid}', '{type}', {state}, {record_type})


### PR DESCRIPTION
This PR adds a rollback engine to Steel. The engine logs any and all changes to the world, physical or virtual, in an SQLite database, then reverts them on request (generally at the end of a round).

Work to do:
- [x] Database logging infrastructure
- [x] Event listeners
- [x] Rollback execution
- [x] Entity rollbacks (paintings, item frames, etc.)
